### PR TITLE
Fixed CI runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'openjdk'
+          distribution: 'temurin'
           java-version: '21'
 
       - name: Cache Gradle dependencies


### PR DESCRIPTION
Two problems were resolved:

- Our branch was named `master` but our CI targetted `main` - I opted to rename the `master` branch rather than changing the CI configuration
- We used an unsupported JDK ("openjdk"), however only JDK distributions on [this page](https://github.com/actions/setup-java?tab=readme-ov-file#supported-distributions) are supported. I switched to `temurin` instead.